### PR TITLE
Ignore Error Types

### DIFF
--- a/client/commands/reporting.py
+++ b/client/commands/reporting.py
@@ -22,6 +22,7 @@ class Reporting(Command):
         self._verbose = arguments.verbose
         self._output = arguments.output
         self._do_not_check_paths = configuration.do_not_check
+        self._ignore_error_types = configuration.ignore_error_types
         self._discovered_analysis_directories = [self._local_root]
         self._local_configuration = arguments.local_configuration
 
@@ -86,6 +87,9 @@ class Reporting(Command):
             relative_path = self._relative_path(full_path)
             error["path"] = relative_path
             do_not_check = False
+            # Make sure this error is not one to be ignored
+            if error["code"] in self._ignore_error_types:
+                do_not_check = True
             external_to_global_root = True
             if full_path.startswith(self._current_directory):
                 external_to_global_root = False

--- a/client/configuration.py
+++ b/client/configuration.py
@@ -81,6 +81,7 @@ class Configuration:
         self.number_of_workers = None
         self.local_configuration = None  # type: Optional[str]
         self.taint_models_path = None
+        self.ignore_error_types = []
 
         self._version_hash = None  # type: Optional[str]
         self._binary = None  # type: Optional[str]
@@ -140,22 +141,22 @@ class Configuration:
     def _validate(self) -> None:
         try:
 
-            def is_list_of_strings(list):
+            def is_list_of_types(list, _type):
                 if len(list) == 0:
                     return True
-                return not isinstance(list, str) and all(
-                    isinstance(element, str) for element in list
+                return not isinstance(list, _type) and all(
+                    isinstance(element, _type) for element in list
                 )
 
-            if not is_list_of_strings(
-                self.analysis_directories
-            ) or not is_list_of_strings(self.targets):
+            if not is_list_of_types(
+                self.analysis_directories, str
+            ) or not is_list_of_types(self.targets, str):
                 raise InvalidConfiguration(
                     "`target` and `analysis_directories` fields must be lists of "
                     "strings."
                 )
 
-            if not is_list_of_strings(self.do_not_check):
+            if not is_list_of_types(self.do_not_check, str):
                 raise InvalidConfiguration(
                     "`do_not_check` field must be a list of strings."
                 )
@@ -167,6 +168,11 @@ class Configuration:
 
             if self.number_of_workers < 1:
                 raise InvalidConfiguration("Number of workers must be greater than 0.")
+
+            if not is_list_of_types(self.ignore_error_types, int):
+                raise InvalidConfiguration(
+                    "`ignore_error_types` field must be a list of integers."
+                )
 
             # Validate typeshed path and sub-elements.
             assert_readable_directory(self.typeshed)
@@ -304,6 +310,8 @@ class Configuration:
                         do_not_check,
                     )
                 )
+
+                self.ignore_error_types.extend(configuration.consume("ignore_error_types", default=[]))
 
                 self.number_of_workers = int(
                     configuration.consume(

--- a/client/tests/configuration_test.py
+++ b/client/tests/configuration_test.py
@@ -35,12 +35,14 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(
             configuration.do_not_check, ["%s/buck-out/dev/gen" % os.getcwd()]
         )
+        self.assertEqual(configuration.ignore_error_types, [])
 
         json_load.side_effect = [
             {
                 "source_directories": ["a"],
                 "logger": "/usr/logger",
                 "do_not_check": ["buck-out/dev/gen"],
+                "ignore_error_types": [9, 16]
             },
             {},
         ]
@@ -51,6 +53,7 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(
             configuration.do_not_check, ["%s/buck-out/dev/gen" % os.getcwd()]
         )
+        self.assertEqual(configuration.ignore_error_types, [9, 16])
 
         json_load.side_effect = [{"targets": ["//a/b/c"], "disabled": 1}, {}]
         configuration = Configuration()
@@ -60,11 +63,13 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(configuration.logger, None)
         self.assertEqual(configuration.do_not_check, [])
         self.assertTrue(configuration.disabled)
+        self.assertEqual(configuration.ignore_error_types, [])
 
         json_load.side_effect = [{"typeshed": "TYPESHED/"}, {}]
         configuration = Configuration()
         self.assertEqual(configuration.typeshed, "TYPESHED/")
         self.assertEqual(configuration.number_of_workers, number_of_workers())
+        self.assertEqual(configuration.ignore_error_types, [])
 
         json_load.side_effect = [
             {
@@ -80,6 +85,7 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(configuration.search_path, ["additional/"])
         self.assertEqual(configuration.number_of_workers, 20)
         self.assertEqual(configuration.taint_models_path, None)
+        self.assertEqual(configuration.ignore_error_types, [])
 
         json_load.side_effect = [
             {
@@ -94,6 +100,7 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(configuration.typeshed, "TYPE/VERSION/SHED/")
         self.assertEqual(configuration.search_path, ["simple_string/"])
         self.assertEqual(configuration.taint_models_path, ".pyre/taint_models")
+        self.assertEqual(configuration.ignore_error_types, [])
 
         # Test loading of additional directories in the search path
         # via environment.
@@ -175,6 +182,17 @@ class ConfigurationTest(unittest.TestCase):
         self.assertEqual(
             configuration.do_not_check,
             ["%s/buck-out/dev/gen" % os.getcwd(), "%s/buck-out/dev/gen2" % os.getcwd()],
+        )
+
+        # Test multiple definitions of the ignore_error_types list.
+        json_load.side_effect = [
+            {"ignore_error_types": [9, 16]},
+            {"ignore_error_types": [18, 21]},
+        ]
+        configuration = Configuration()
+        self.assertEqual(
+            configuration.ignore_error_types,
+            [9, 16, 18, 21],
         )
 
         # Normalize number of workers if zero.
@@ -357,4 +375,5 @@ class ConfigurationTest(unittest.TestCase):
             self.assertEqual(configuration.logger, None)
             self.assertEqual(configuration.do_not_check, [])
             self.assertFalse(configuration.disabled)
+            self.assertEqual(configuration.ignore_error_types, [])
             self.assertEqual(configuration._typeshed, None)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ provides typed stubs for library functions.
 
 `workers`: Number of workers to spawn for multiprocessing.
 
+`ignore_error_types`: A list of error types to ignore from type-checking. The list of types can be found [here](https://pyre-check.org/docs/error-types.html)
 
 # Local Configuration
 If you have sub-projects within your project root that you would like to run Pyre on, you


### PR DESCRIPTION
This commit adds support for ignoring error types. One can ignore error types by error type code in the command line or in the configuration file.